### PR TITLE
Fix mobile sidebar visibility

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -101,7 +101,7 @@ interface SidebarSubItemProps {
   depth: number;
   sectionName: string;
   currentPath: string;
-  navigate: ReturnType<typeof useNavigate>;
+  navigate: (path: string) => void;
   edition: string;
   onUpsell: () => void;
 }
@@ -182,7 +182,7 @@ interface SidebarTopItemProps {
   item: LayoutItem;
   sectionName: string;
   currentPath: string;
-  navigate: ReturnType<typeof useNavigate>;
+  navigate: (path: string) => void;
   edition: string;
   onUpsell: () => void;
 }
@@ -262,6 +262,7 @@ export function Sidebar() {
   const activeSection = useUIStore((s) => s.activeSection);
   const setActiveSection = useUIStore((s) => s.setActiveSection);
   const sidebarOpen = useUIStore((s) => s.sidebarOpen);
+  const setSidebarOpen = useUIStore((s) => s.setSidebarOpen);
   const schema = useSchemaStore((s) => s.schema);
   const edition = useAccountStore((s) => s.edition);
   const hasObjectPermission = useAccountStore((s) => s.hasObjectPermission);
@@ -287,68 +288,84 @@ export function Sidebar() {
   const layout: Layout | undefined = layouts.find((l) => l.name === activeSection);
   if (!layout) return null;
 
+  const navigateAndClose = (path: string) => {
+    navigate(path);
+    if (window.matchMedia('(max-width: 767px)').matches) {
+      setSidebarOpen(false);
+    }
+  };
+
   const handleSectionClick = (target: Layout) => {
     setActiveSection(target.name);
     const canGet = (prefix: string) => hasObjectPermission(prefix, 'Get');
     const first =
       findFirstAccessibleLinkInLayout(schema, target, edition, canGet, hasPermission) ??
       findFirstVisibleLinkInLayout(schema, target, edition, canGet, hasPermission);
-    if (first) navigate(`/${target.name}/${first}`);
+    if (first) navigateAndClose(`/${target.name}/${first}`);
   };
 
   return (
-    <aside className="fixed top-14 left-0 bottom-0 z-30 hidden w-64 flex-col border-r bg-background md:flex">
-      <ScrollArea className="flex-1 py-2">
-        <nav className="flex flex-col gap-0.5 px-2">
-          {layout.items.map((item) => (
-            <SidebarTopItem
-              key={'link' in item ? item.link.viewName : item.container.name}
-              item={item}
-              sectionName={layout.name}
-              currentPath={location.pathname}
-              navigate={navigate}
-              edition={edition}
-              onUpsell={() => setUpsellOpen(true)}
-            />
-          ))}
-        </nav>
-      </ScrollArea>
+    <>
+      <button
+        type="button"
+        className="fixed inset-x-0 top-14 bottom-0 z-20 bg-background/80 backdrop-blur-sm md:hidden"
+        aria-label="Close sidebar"
+        onClick={() => setSidebarOpen(false)}
+      />
 
-      {layouts.length > 1 && (
-        <TooltipProvider>
-          <div className="flex items-center justify-around border-t bg-background px-2 py-2">
-            {layouts.map((target) => {
-              const Icon = (LucideIcons as Record<string, unknown>)[
-                target.icon
-                  .split('-')
-                  .map((s) => s[0].toUpperCase() + s.slice(1))
-                  .join('')
-              ] as LucideIcons.LucideIcon | undefined;
-              const isActive = target.name === activeSection;
-              return (
-                <Tooltip key={target.name}>
-                  <TooltipTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      aria-label={target.name}
-                      aria-current={isActive ? 'page' : undefined}
-                      onClick={() => handleSectionClick(target)}
-                      className={cn('h-9 w-9', isActive && 'bg-accent text-accent-foreground')}
-                    >
-                      {Icon ? <Icon className="h-4 w-4" /> : <LucideIcons.Circle className="h-4 w-4" />}
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="top">{target.name}</TooltipContent>
-                </Tooltip>
-              );
-            })}
-          </div>
-        </TooltipProvider>
-      )}
+      <aside className="fixed top-14 left-0 bottom-0 z-30 flex w-64 flex-col border-r bg-background shadow-lg md:shadow-none">
+        <ScrollArea className="flex-1 py-2">
+          <nav className="flex flex-col gap-0.5 px-2">
+            {layout.items.map((item) => (
+              <SidebarTopItem
+                key={'link' in item ? item.link.viewName : item.container.name}
+                item={item}
+                sectionName={layout.name}
+                currentPath={location.pathname}
+                navigate={navigateAndClose}
+                edition={edition}
+                onUpsell={() => setUpsellOpen(true)}
+              />
+            ))}
+          </nav>
+        </ScrollArea>
 
-      <EnterpriseUpsell open={upsellOpen} onClose={() => setUpsellOpen(false)} />
-    </aside>
+        {layouts.length > 1 && (
+          <TooltipProvider>
+            <div className="flex items-center justify-around border-t bg-background px-2 py-2">
+              {layouts.map((target) => {
+                const Icon = (LucideIcons as Record<string, unknown>)[
+                  target.icon
+                    .split('-')
+                    .map((s) => s[0].toUpperCase() + s.slice(1))
+                    .join('')
+                ] as LucideIcons.LucideIcon | undefined;
+                const isActive = target.name === activeSection;
+                return (
+                  <Tooltip key={target.name}>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        aria-label={target.name}
+                        aria-current={isActive ? 'page' : undefined}
+                        onClick={() => handleSectionClick(target)}
+                        className={cn('h-9 w-9', isActive && 'bg-accent text-accent-foreground')}
+                      >
+                        {Icon ? <Icon className="h-4 w-4" /> : <LucideIcons.Circle className="h-4 w-4" />}
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">{target.name}</TooltipContent>
+                  </Tooltip>
+                );
+              })}
+            </div>
+          </TooltipProvider>
+        )}
+
+        <EnterpriseUpsell open={upsellOpen} onClose={() => setUpsellOpen(false)} />
+      </aside>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

Fixes the mobile sidebar drawer so the hamburger button can actually display navigation below the `md` breakpoint.

The top bar already renders a hamburger button on small screens and calls `toggleSidebar()`, but `Sidebar` used `hidden md:flex`, so it stayed hidden on mobile even when `sidebarOpen` was true.

## Changes

- Render the sidebar when `sidebarOpen` is true on mobile instead of forcing `hidden md:flex`
- Add a mobile backdrop that closes the sidebar
- Close the mobile sidebar after navigating from a sidebar item or section shortcut
- Keep desktop sidebar behavior unchanged

## Testing

- `pnpm run typecheck`
- `pnpm run build`
- Built a `webui.zip` and tested it through Stalwart's `Application.resourceUrl` on a live instance; the mobile hamburger now opens the sidebar.

Authored-by: Codex <noreply@codex.openai.com>
